### PR TITLE
Polish the S-expression pretty printing

### DIFF
--- a/backend/PrintCminor.ml
+++ b/backend/PrintCminor.ml
@@ -23,63 +23,46 @@ open AST
 open PrintAST
 open Cminor
 
-(* Precedences and associativity -- like those of C *)
-
-type associativity = LtoR | RtoL | NA
-
-let precedence = function
-  | Evar _ -> (16, NA)
-  | Econst _ -> (16, NA)
-  | Eunop _ -> (15, RtoL)
-  | Ebinop((Omul|Odiv|Odivu|Omod|Omodu|Omulf|Odivf|Omulfs|Odivfs|Omull|Odivl|Odivlu|Omodl|Omodlu), _, _) -> (13, LtoR)
-  | Ebinop((Oadd|Osub|Oaddf|Osubf|Oaddfs|Osubfs|Oaddl|Osubl), _, _) -> (12, LtoR)
-  | Ebinop((Oshl|Oshr|Oshru|Oshll|Oshrl|Oshrlu), _, _) -> (11, LtoR)
-  | Ebinop((Ocmp _|Ocmpu _|Ocmpf _|Ocmpfs _|Ocmpl _|Ocmplu _), _, _) -> (10, LtoR)
-  | Ebinop((Oand|Oandl), _, _) -> (8, LtoR)
-  | Ebinop((Oxor|Oxorl), _, _) -> (7, LtoR)
-  | Ebinop((Oor|Oorl), _, _) -> (6, LtoR)
-  | Eload _ -> (15, RtoL)
-
 (* Naming idents. *)
 
-let ident_name id = "'" ^ Camlcoq.extern_atom id ^ "'"
+let ident_name id = Camlcoq.extern_atom id
 
 (* Naming operators *)
 
 let name_of_unop = function
-  | Ocast8unsigned -> "int8u"
-  | Ocast8signed -> "int8s"
-  | Ocast16unsigned -> "int16u"
-  | Ocast16signed -> "int16s"
-  | Onegint -> "Onegint"
-  | Onotint -> "~"
-  | Onegf -> "-f"
-  | Oabsf -> "absf"
-  | Onegfs -> "-s"
-  | Oabsfs -> "abss"
-  | Osingleoffloat -> "float32"
-  | Ofloatofsingle -> "float64"
-  | Ointoffloat -> "intoffloat"
-  | Ointuoffloat -> "intuoffloat"
-  | Ofloatofint -> "floatofint"
-  | Ofloatofintu -> "floatofintu"
-  | Ointofsingle -> "intofsingle"
-  | Ointuofsingle -> "intuofsingle"
-  | Osingleofint -> "singleofint"
-  | Osingleofintu -> "singleofintu"
-  | Onegl -> "-l"
-  | Onotl -> "~l"
-  | Ointoflong -> "intoflong"
-  | Olongofint -> "longofint"
-  | Olongofintu -> "longofintu"
-  | Olongoffloat -> "longoffloat"
-  | Olonguoffloat -> "longuoffloat"
-  | Ofloatoflong -> "floatoflong"
-  | Ofloatoflongu -> "floatoflongu"
-  | Olongofsingle -> "longofsingle"
-  | Olonguofsingle -> "longuofsingle"
-  | Osingleoflong -> "singleoflong"
-  | Osingleoflongu -> "singleoflongu"
+  | Ocast8unsigned  -> "Ocast8unsigned"
+  | Ocast8signed    -> "Ocast8signed"
+  | Ocast16unsigned -> "Ocast16unsigned"
+  | Ocast16signed   -> "Ocast16signed"
+  | Onegint         -> "Onegint"
+  | Onotint         -> "Onotint"
+  | Onegf           -> "Onegf"
+  | Oabsf           -> "Oabsf"
+  | Onegfs          -> "Onegfs"
+  | Oabsfs          -> "Oabsfs"
+  | Osingleoffloat  -> "Osingleoffloat"
+  | Ofloatofsingle  -> "Ofloatofsingle"
+  | Ointoffloat     -> "Ointoffloat"
+  | Ointuoffloat    -> "Ointuoffloat"
+  | Ofloatofint     -> "Ofloatofint"
+  | Ofloatofintu    -> "Ofloatofintu"
+  | Ointofsingle    -> "Ointofsingle"
+  | Ointuofsingle   -> "Ointuofsingle"
+  | Osingleofint    -> "Osingleofint"
+  | Osingleofintu   -> "Osingleofintu"
+  | Onegl           -> "Onegl"
+  | Onotl           -> "Onotl"
+  | Ointoflong      -> "Ointoflong"
+  | Olongofint      -> "Olongofint"
+  | Olongofintu     -> "Olongofintu"
+  | Olongoffloat    -> "Olongoffloat"
+  | Olonguoffloat   -> "Olonguoffloat"
+  | Ofloatoflong    -> "Ofloatoflong"
+  | Ofloatoflongu   -> "Ofloatoflongu"
+  | Olongofsingle   -> "Olongofsingle"
+  | Olonguofsingle  -> "Olonguofsingle"
+  | Osingleoflong   -> "Osingleoflong"
+  | Osingleoflongu  -> "Osingleoflongu"
 
 let comparison_name = function
   | Ceq -> "Ceq"
@@ -90,110 +73,109 @@ let comparison_name = function
   | Cge -> "Cge"
 
 let name_of_binop = function
-  | Oadd -> "Oadd"
-  | Osub -> "Osub"
-  | Omul -> "Omul"
-  | Odiv -> "Odiv"
-  | Odivu -> "/u"
-  | Omod -> "%"
-  | Omodu -> "%u"
-  | Oand -> "&"
-  | Oor -> "|"
-  | Oxor -> "^"
-  | Oshl -> "<<"
-  | Oshr -> ">>"
-  | Oshru -> ">>u"
-  | Oaddf -> "+f"
-  | Osubf -> "-f"
-  | Omulf -> "*f"
-  | Odivf -> "/f"
-  | Oaddfs -> "+s"
-  | Osubfs -> "-s"
-  | Omulfs -> "*s"
-  | Odivfs -> "/s"
-  | Oaddl -> "+l"
-  | Osubl -> "-l"
-  | Omull -> "*l"
-  | Odivl -> "/l"
-  | Odivlu -> "/lu"
-  | Omodl -> "%l"
-  | Omodlu -> "%lu"
-  | Oandl -> "&l"
-  | Oorl -> "|l"
-  | Oxorl -> "^l"
-  | Oshll -> "<<l"
-  | Oshrl -> ">>l"
-  | Oshrlu -> ">>lu"
-  | Ocmp c -> "(Ocmp " ^ comparison_name c ^ ")"
-  | Ocmpu c -> comparison_name c ^ "u"
-  | Ocmpf c -> comparison_name c ^ "f"
-  | Ocmpfs c -> comparison_name c ^ "s"
-  | Ocmpl c -> comparison_name c ^ "l"
-  | Ocmplu c -> comparison_name c ^ "lu"
+  | Oadd     -> "Oadd"
+  | Osub     -> "Osub"
+  | Omul     -> "Omul"
+  | Odiv     -> "Odiv"
+  | Odivu    -> "Odivu"
+  | Omod     -> "Omod"
+  | Omodu    -> "Omodu"
+  | Oand     -> "Oand"
+  | Oor      -> "Oor"
+  | Oxor     -> "Oxor"
+  | Oshl     -> "Oshl"
+  | Oshr     -> "Oshr"
+  | Oshru    -> "Oshru"
+  | Oaddf    -> "Oaddf"
+  | Osubf    -> "Osubf"
+  | Omulf    -> "Omulf"
+  | Odivf    -> "Odivf"
+  | Oaddfs   -> "Oaddfs"
+  | Osubfs   -> "Osubfs"
+  | Omulfs   -> "Omulfs"
+  | Odivfs   -> "Odivfs"
+  | Oaddl    -> "Oaddl"
+  | Osubl    -> "Osubl"
+  | Omull    -> "Omull"
+  | Odivl    -> "Odivl"
+  | Odivlu   -> "Odivlu"
+  | Omodl    -> "Omodl"
+  | Omodlu   -> "Omodlu"
+  | Oandl    -> "Oandl"
+  | Oorl     -> "Oorl"
+  | Oxorl    -> "Oxorl"
+  | Oshll    -> "Oshll"
+  | Oshrl    -> "Oshrl"
+  | Oshrlu   -> "Oshrlu"
+  | Ocmp c   -> "(Ocmp " ^ comparison_name c ^")"
+  | Ocmpu c  -> "(Ocmpu " ^ comparison_name c ^")"
+  | Ocmpf c  -> "(Ocmpf " ^ comparison_name c ^")"
+  | Ocmpfs c -> "(Ocmpfs " ^ comparison_name c ^")"
+  | Ocmpl c  -> "(Ocmpl " ^ comparison_name c ^")"
+  | Ocmplu c -> "(Ocmplu " ^ comparison_name c ^")"
 
 (* Expressions *)
 
-let rec expr p (prec, e) =
-  let (prec', assoc) = precedence e in
-  let (prec1, prec2) =
-    if assoc = LtoR
-    then (prec', prec' + 1)
-    else (prec' + 1, prec') in
-  if prec' < prec
-  then fprintf p "@[<hov 2>("
-  else fprintf p "@[<hov 2>";
+let rec expr p e =
+  fprintf p "@[<hov 2>";
   begin match e with
   | Evar id ->
       fprintf p "(Evar %s)" (ident_name id)
   | Econst(Ointconst n) ->
       fprintf p "(Econst (Ointconst %ld))" (camlint_of_coqint n)
   | Econst(Ofloatconst f) ->
-      fprintf p "%.15F" (camlfloat_of_coqfloat f)
+      fprintf p "(Econst (Ofloatconst %.15F))" (camlfloat_of_coqfloat f)
   | Econst(Osingleconst f) ->
-      fprintf p "%.15Ff" (camlfloat_of_coqfloat32 f)
+      fprintf p "(Econst (Osingleconst %.15Ff))" (camlfloat_of_coqfloat32 f)
   | Econst(Olongconst n) ->
-      fprintf p "%LdLL" (camlint64_of_coqint n)
+      fprintf p "(Econst (Olongconst %LdLL))" (camlint64_of_coqint n)
   | Econst(Oaddrsymbol(id, ofs)) ->
       let ofs = camlint_of_coqint ofs in
-      if ofs = 0l
-      then fprintf p "\"%s\"" (extern_atom id)
-      else fprintf p "(\"%s\" + %ld)" (extern_atom id) ofs
+      fprintf p "(Econst (Oaddrsymbol %s %ld))" (extern_atom id) ofs
   | Econst(Oaddrstack n) ->
-      fprintf p "&%ld" (camlint_of_coqint n)
+      fprintf p "(Econst (Oaddrstack %ld))" (camlint_of_coqint n)
   | Eunop(op, a1) ->
-      fprintf p "(Eunop %s %a)" (name_of_unop op) expr (prec', a1)
+      fprintf p "(Eunop %s %a)" (name_of_unop op) expr a1
   | Ebinop(op, a1, a2) ->
-      fprintf p "(Ebinop %s %a %a)" (name_of_binop op) expr (prec1, a1) expr (prec2, a2)
+      fprintf p "(Ebinop %s@ %a@ %a)"
+        (name_of_binop op) expr a1 expr a2
   | Eload(chunk, a1) ->
-      fprintf p "%s[%a]" (name_of_chunk chunk) expr (0, a1)
+      fprintf p "(Eload %s %a)" (name_of_chunk chunk) expr a1
   end;
-  if prec' < prec then fprintf p ")@]" else fprintf p "@]"
+  fprintf p "@]"
 
-let print_expr p e = expr p (0, e)
+let print_expr p e = expr p e
 
 let rec print_expr_list p (first, rl) =
   match rl with
   | [] -> ()
   | r :: rl ->
       if not first then fprintf p ",@ ";
-      expr p (2, r);
+      expr p r;
       print_expr_list p (false, rl)
 
 (* Types *)
 
 let name_of_type = function
-  | Tint -> "int"
-  | Tfloat -> "float"
-  | Tlong -> "long"
-  | Tsingle -> "single"
-  | Tany32 -> "any32"
-  | Tany64 -> "any64"
+  | Tint -> "Tint"
+  | Tfloat -> "Tfloat"
+  | Tlong -> "Tlong"
+  | Tsingle -> "Tsingle"
+  | Tany32 -> "Tany32"
+  | Tany64 -> "Tany64"
+
+let rec print_type_list p (first, tl) =
+  match tl with
+  | [] -> ()
+  | t :: tl ->
+     if not first then fprintf p "@ ";
+     fprintf p "%s" (name_of_type t);
+     print_type_list p (false, tl)
 
 let print_sig p sg =
-  List.iter
-    (fun t -> fprintf p "%s ->@ " (name_of_type t))
-    sg.sig_args;
-  fprintf p "%s" (name_of_rettype sg.sig_res)
+  fprintf p "@[<hov 0>(signature@ (%a)@ %s)@]"
+    print_type_list (true, sg.sig_args)
+    (name_of_rettype sg.sig_res)
 
 let rec just_skips s =
   match s with
@@ -211,7 +193,7 @@ let rec print_stmt p s =
   | Sassign(id, e2) ->
       fprintf p "@[<hv 2>(Sassign %s %a)@]" (ident_name id) print_expr e2
   | Sstore(chunk, a1, a2) ->
-      fprintf p "@[<hv 2>%s[%a] =@ %a;@]"
+      fprintf p "@[<hv 2>(Sstore %s %a@ %a)@]"
               (name_of_chunk chunk) print_expr a1 print_expr a2
   | Scall(None, sg, e1, el) ->
       fprintf p "@[<hv 2>%a@,(@[<hov 0>%a@])@ : @[<hov 0>%a@];@]"
@@ -240,14 +222,14 @@ let rec print_stmt p s =
                 (name_of_external ef)
                 print_expr_list (true, el)
 	        print_sig (ef_sig ef)
-(*  | Sseq(s1,s2) when just_skips s1 && just_skips s2 ->
-      () 
+  | Sseq(s1,s2) when just_skips s1 && just_skips s2 ->
+      fprintf p "(Sskip)"
   | Sseq(s1, s2) when just_skips s1 ->
       print_stmt p s2
   | Sseq(s1, s2) when just_skips s2 ->
-      print_stmt p s1 *)
+      print_stmt p s1
   | Sseq(s1, s2) ->
-      fprintf p "@[<hv 2>(Sseq @[<1>@ %a @ %a@])@]" print_stmt s1 print_stmt s2
+      fprintf p "@[<v 2>(Sseq %a@ %a)@]" print_stmt s1 print_stmt s2
 (*  | Sifthenelse(e, s1, Sskip) ->
       fprintf p "@[<v 2>if (%a) {@ %a@;<0 -2>}@]"
               print_expr e
@@ -257,18 +239,18 @@ let rec print_stmt p s =
               expr (15, e)
               print_stmt s2 *)
   | Sifthenelse(e, s1, s2) ->
-      fprintf p "@[<hv 2>(Sifthenelse @[<1>@ %a @ %a @ %a@])@]"
+      fprintf p "@[<v 2>(Sifthenelse %a@ %a@ %a)@]"
               print_expr e
               print_stmt s1
               print_stmt s2
   | Sloop(s) ->
-      fprintf p "@[<v 2>loop {@ %a@;<0 -2>}@]"
+      fprintf p "@[<v 2>(Sloop@ %a)@]"
               print_stmt s
   | Sblock(s) ->
-      fprintf p "@[<v 3>{{ %a@;<0 -3>}}@]"
+      fprintf p "@[<v 2>(Sblock@ %a)@]"
               print_stmt s
   | Sexit n ->
-      fprintf p "exit %d;" (Nat.to_int n)
+      fprintf p "(Sexit %d)" (Nat.to_int n)
   | Sswitch(long, e, cases, dfl) ->
     let print_case (n,x) =
       let x = Nat.to_int x in
@@ -282,15 +264,13 @@ let rec print_stmt p s =
       fprintf p "@ default: exit %d;\n" (Nat.to_int dfl);
       fprintf p "@;<0 -2>}@]"
   | Sreturn None ->
-      fprintf p "return;"
+      fprintf p "(Sreturn)"
   | Sreturn (Some e) ->
       fprintf p "(Sreturn %a)" print_expr e
   | Slabel(lbl, s1) ->
-      fprintf p "%s:@ %a" (ident_name lbl) print_stmt s1  (* wrong for Cminorgen output *)
+      fprintf p "(Slabel %s@ %a)" (ident_name lbl) print_stmt s1  (* wrong for Cminorgen output *)
   | Sgoto lbl ->
-      fprintf p "goto %s;" (ident_name lbl)               (* wrong for Cminorgen output *)
-
-    
+      fprintf p "(Sgoto %s)" (ident_name lbl)               (* wrong for Cminorgen output *)
 
 (* Functions *)
 
@@ -298,26 +278,23 @@ let rec print_varlist p (vars, first) =
   match vars with
   | [] -> ()
   | v1 :: vl ->
-      if not first then fprintf p ",@ ";
+      if not first then fprintf p "@ ";
       fprintf p "%s" (ident_name v1);
       print_varlist p (vl, false)
 
 let print_function p id f =
-  fprintf p "@[<hov 4>\"%s\"(@[<hov 0>%a@])@ : @[<hov 0>%a@]@]@ "
+  fprintf p "@[<hov 2>(procedure %s@ (@[<hov 0>%a@])@ @[<hov 0>%a@]@ "
             (extern_atom id)
             print_varlist (f.fn_params, true)
             print_sig f.fn_sig;
-  fprintf p "@[<v 2>{@ ";
   let stksz = Z.to_int32 f.fn_stackspace in
-  if stksz <> 0l then
-    fprintf p "stack %ld;@ " stksz;
-  if f.fn_vars <> [] then
-    fprintf p "var @[<hov 0>%a;@]@ " print_varlist (f.fn_vars, true);
+  fprintf p "(stack %ld)@ " stksz;
+  fprintf p "(vars@[<hov 0>%a)@]@ " print_varlist (f.fn_vars, false);
   print_stmt p f.fn_body;
-  fprintf p "@;<0 -2>}@]@ "
+  fprintf p ")@]@ "
 
 let print_extfun p id ef =
-  fprintf p "@[<v 0>extern @[<hov 2>\"%s\" =@ %s :@ %a@]@]@ "
+  fprintf p "@[<v 2>(extern@ %s@ (%s)@ %a)@]@ "
     (extern_atom id) (name_of_external ef) print_sig (ef_sig ef)
 
 let print_init_data p = function
@@ -350,18 +327,18 @@ let print_globvar p gv =
 let print_globdef p (id, gd) =
   match gd with
   | Gfun(External ef) ->
-      print_extfun p id ef
+      () (* print_extfun p id ef *)
   | Gfun(Internal f) ->
       print_function p id f
   | Gvar gv ->
-     fprintf p "var \"%s\" %a\n" (extern_atom id) print_globvar gv
+     fprintf p "(globalvar %s %a)\n" (extern_atom id) print_globvar gv
 
 let print_program p prog =
-  fprintf p "@[<v 0>";
+  fprintf p "@[<hov 2>(program@ ";
   if extern_atom prog.prog_main <> "main" then
     fprintf p "= \"%s\"\n" (extern_atom prog.prog_main);
   List.iter (print_globdef p) prog.prog_defs;
-  fprintf p "@]@."
+  fprintf p ")@]@."
 
 let destination : string option ref = ref None
 

--- a/common/PrintAST.ml
+++ b/common/PrintAST.ml
@@ -21,32 +21,32 @@ open Camlcoq
 open AST
 
 let name_of_type = function
-  | Tint -> "int"
-  | Tfloat -> "float"
-  | Tlong -> "long"
-  | Tsingle -> "single"
-  | Tany32 -> "any32"
-  | Tany64 -> "any64"
+  | Tint -> "Tint"
+  | Tfloat -> "Tfloat"
+  | Tlong -> "Tlong"
+  | Tsingle -> "Tsingle"
+  | Tany32 -> "Tany32"
+  | Tany64 -> "Tany64"
 
 let name_of_rettype = function
-  | Tret t -> name_of_type t
-  | Tvoid -> "void"
-  | Tint8signed -> "int8s"
-  | Tint8unsigned -> "int8u"
-  | Tint16signed -> "int16s"
-  | Tint16unsigned -> "int16u"
+  | Tret t -> "(Tret " ^ name_of_type t ^ ")"
+  | Tvoid -> "Tvoid"
+  | Tint8signed -> "Tint8signed"
+  | Tint8unsigned -> "Tint8unsigned"
+  | Tint16signed -> "Tint16signed"
+  | Tint16unsigned -> "Tint16unsigned"
 
 let name_of_chunk = function
-  | Mint8signed -> "int8s"
-  | Mint8unsigned -> "int8u"
-  | Mint16signed -> "int16s"
-  | Mint16unsigned -> "int16u"
-  | Mint32 -> "int32"
-  | Mint64 -> "int64"
-  | Mfloat32 -> "float32"
-  | Mfloat64 -> "float64"
-  | Many32 -> "any32"
-  | Many64 -> "any64"
+  | Mint8signed -> "Mint8signed"
+  | Mint8unsigned -> "Mint8unsigned"
+  | Mint16signed -> "Mint16signed"
+  | Mint16unsigned -> "Mint16unsigned"
+  | Mint32 -> "Mint32"
+  | Mint64 -> "Mint64"
+  | Mfloat32 -> "Mfloat32"
+  | Mfloat64 -> "Mfloat64"
+  | Many32 -> "Many32"
+  | Many64 -> "Many64"
 
 let name_of_external = function
   | EF_external(name, sg) -> sprintf "extern %S" (camlstring_of_coqstring name)


### PR DESCRIPTION
* Pretty print more type and op constructors as symbols
* Pretty print some more cases of statement
* Reintroduce the just_skips pretty printing of Sseq to reduce the output
* Remove whitespace from Sifthenelse and Sseq
* Pretty print function signatures
* Always print stack size and local vars
* Pretty print program